### PR TITLE
[PR] SSE 서버시간 전송

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { FirebaseModule } from './firebase/firebase.module';
 import { AuthModule } from './auth/auth.module';
 import { MessageModule } from './message/message.module';
 import { ConfigModule } from '@nestjs/config';
+import { SseModule } from './sse/sse.module';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
@@ -38,6 +39,7 @@ export class LoggerMiddleware implements NestMiddleware {
       isGlobal: true,
       envFilePath: `.env`,
     }),
+    SseModule,
   ],
   controllers: [],
   providers: [],

--- a/src/sse/sse.controller.spec.ts
+++ b/src/sse/sse.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SseController } from './sse.controller';
+
+describe('SseController', () => {
+  let controller: SseController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SseController],
+    }).compile();
+
+    controller = module.get<SseController>(SseController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/sse/sse.controller.ts
+++ b/src/sse/sse.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, MessageEvent, Sse } from '@nestjs/common';
+import { interval, map, Observable } from 'rxjs';
+
+@Controller('sse')
+export class SseController {
+  // 10초에 한번씩 서버 시간 전송
+  @Sse('time')
+  sse(): Observable<MessageEvent> {
+    return interval(5000).pipe(
+      map(() => ({
+        data: { unixTime: Math.floor(new Date().getTime() / 1000) },
+      })),
+    );
+  }
+}

--- a/src/sse/sse.controller.ts
+++ b/src/sse/sse.controller.ts
@@ -1,9 +1,31 @@
 import { Controller, MessageEvent, Sse } from '@nestjs/common';
 import { interval, map, Observable } from 'rxjs';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-@Controller('sse')
+@ApiTags('SSE')
+@Controller('/api/v1/sse')
 export class SseController {
   // 10초에 한번씩 서버 시간 전송
+  @ApiOperation({
+    summary: 'SSE로 5초에 한번씩 서버 시간 unixTimestamp로 전송',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'OK',
+    content: {
+      'text/event-stream': {
+        schema: {
+          type: 'object',
+          properties: {
+            unixTime: {
+              example: 1627666800,
+              type: 'number',
+            },
+          },
+        },
+      },
+    },
+  })
   @Sse('time')
   sse(): Observable<MessageEvent> {
     return interval(5000).pipe(

--- a/src/sse/sse.module.ts
+++ b/src/sse/sse.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { SseController } from './sse.controller';
+
+@Module({
+  controllers: [SseController]
+})
+export class SseModule {}


### PR DESCRIPTION
## Summary
SSE를 이용해서 서버 시간 5초 간격으로 전송
time gap 계산이 간편하도록 unixsecond형태로 전송함
** (SSE: 웹소켓과 유사하지만 서버에서 단방향으로 실시간 전송할 수 있는 HTTP기반 프로토콜)


## Description
- SSE 연결을 위한 컨트롤러 추가

## 추가 논의가 필요한 부분
- 서버 시간 전송 주기
- 구형 브라우저에 대한 지원이 필요한지 (필요할 경우 pollyfills필요)

## Screenshots
![image](https://github.com/TUK-IT-STARTUP-CAMP-TASK/Backend/assets/88549117/54bba242-e34a-4507-b54a-5f0331fd97bb)

## Test Checklist
- [x] 5초 간격으로 현재 시간이 잘 들어오는지 Postman으로 확인 (일반 Get요청하듯이 요청하면 데이터 들어옴)